### PR TITLE
Update Redis pipeline command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Kostis Dadamis
 Emili Parreno
+Carlos Lopes

--- a/lib/money/rates_store/historical_redis.rb
+++ b/lib/money/rates_store/historical_redis.rb
@@ -89,10 +89,10 @@ class Money
                                'be equal to 1'
         end
 
-        @redis.pipelined do
+        @redis.pipelined do |pipeline|
           currency_date_rate_hash.each do |iso_currency, iso_date_rate_hash|
             k = key(iso_currency)
-            @redis.mapped_hmset(k, iso_date_rate_hash)
+            pipeline.mapped_hmset(k, iso_date_rate_hash)
           end
         end
       rescue Redis::BaseError => e


### PR DESCRIPTION
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0